### PR TITLE
fix: changing repo name in pythonpath

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -28,7 +28,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Set pythonpath
         run: |
-          echo "PYTHONPATH=/home/runner/work/speech_verification_public/speech_verification_public/" >> $GITHUB_ENV
+          echo "PYTHONPATH=/home/runner/work/speaker-verification/speaker-verification/" >> $GITHUB_ENV
       - name: Test with pytest
         run: |
           pytest speaker_verification/


### PR DESCRIPTION
Due to changing the repo name from 2020 T3 we need to modify the pythonpath supplied to the CI pipeline.
We won't be able to check the changes until it is merged into the `main` branch.